### PR TITLE
[Featurebase] remove default board

### DIFF
--- a/src/components/Featurebase/Featurebase.tsx
+++ b/src/components/Featurebase/Featurebase.tsx
@@ -55,7 +55,6 @@ const Featurebase = () => {
     // Initialize Feedback widget
     win.Featurebase('initialize_feedback_widget', {
       ...mainConfig,
-      defaultBoard: '✨ Espace cadre',
     })
   }, [currentUser, enableFeaturebase, featurebaseToken])
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `defaultBoard` property from the Featurebase configuration, enhancing widget initialization.
  
- **Refactor**
	- Maintained the overall structure and logic of the Featurebase component while improving clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->